### PR TITLE
Do not invoke filter(predicate) if Optional value is empty.

### DIFF
--- a/lib/optional.js
+++ b/lib/optional.js
@@ -24,7 +24,7 @@ Optional.prototype = {
         if (!isFunction(predicate)) {
             throw new Error('NullPointerException : predicate is not a function');
         }
-        if (predicate(this._value)) {
+        if (!isNull(this._value) && predicate(this._value)) {
             return new Optional(this._value);
         }
         return new Optional();

--- a/test/optional-test.js
+++ b/test/optional-test.js
@@ -137,6 +137,12 @@ describe('Optional.js', function () {
             }, /NullPointerException : predicate is not a function/);
         });
 
+        it('.filter() should not regard predicate if Optional is empty', function () {
+            emptyOptional.filter(function predicate(value) {
+                throw new Error('Predicate was invoked on empty Optional');
+            });
+        });
+
         it('.map() on non empty Optional, returns a new Optional describing the mapped value, if mapper returns non-null value', function () {
             var expectedValue = nonNullValue + 100,
                 mappedOptional = nonNullOptional.map(function (value) {


### PR DESCRIPTION
I think `Optional.filter` should not regard invoke the predicate argument if `this._value` is empty. Otherwise, you might end up with "null pointers" within the filter if you are doing something like the following:

```javascript
// Non-empty scenario
Optional.ofNullable({ someProp: true })
    .filter(function(val) { return val.someProp; })
    .ifPresent(function(val) { console.log(val); });
```

```javascript
// Empty scenario
Optional.ofNullable(null)
    .filter(function(val) { return val.someProp; }) // TypeError: Cannot read property 'someProp' of null
    .ifPresent(function(val) { console.log(val); });
```