### PR TITLE
Add .peek() function to Optional.

### DIFF
--- a/lib/optional.js
+++ b/lib/optional.js
@@ -63,6 +63,20 @@ Optional.prototype = {
 
         return flatMappedValue;
     },
+    peek: function peek(peeker) {
+
+        if (!isFunction(peeker)) {
+            throw new Error('NullPointerException : peeker is not a function');
+        }
+
+        if (isNull(this._value)) {
+            return new Optional();
+        }
+
+        peeker(this._value);
+
+        return isNull(this._value) ? new Optional() : new Optional(this._value);
+    },
     orElse: function orElse(other) {
         return isNull(this._value) ? other : this._value;
     },

--- a/test/optional-test.js
+++ b/test/optional-test.js
@@ -212,6 +212,21 @@ describe('Optional.js', function () {
             }, /NullPointerException : mapper does not return an Optional/);
         });
 
+        it('.peek() on non empty Optional, peeks the value with no side effects', function () {
+            var expectedValue = nonNullOptional.get(),
+                result = nonNullOptional.peek(function (value) {
+                    return "something else";
+                });
+
+            assert.strictEqual(result.get(), expectedValue);
+        });
+
+        it('.peek() throws an exception if mapper is not a function', function () {
+            assert.throws(function () {
+                nonNullOptional.peek('not a function');
+            }, /NullPointerException : peeker is not a function/)
+        });
+
         it('.orElse() on non empty Optional, returns the value', function () {
             var result = nonNullOptional.orElse('an orElse value');
 


### PR DESCRIPTION
I have been annoyed that there is no `.peek()` function for a long time! `.peek()` is a function which accepts a function as argument which causes no side effect, unlike map. Quite useful for logging and similar.

I have borrowed the `peek` name from Scala, but I am open for other suggestions.