### PR TITLE
Remove redundant code in peek function.

### DIFF
--- a/lib/optional.js
+++ b/lib/optional.js
@@ -74,7 +74,7 @@ Optional.prototype = {
 
         peeker(this._value);
 
-        return isNull(this._value) ? new Optional() : new Optional(this._value);
+        return new Optional(this._value);
     },
     orElse: function orElse(other) {
         return isNull(this._value) ? other : this._value;


### PR DESCRIPTION
Not sure why I introduced this extra redundant complexity. Would be nice to remove.