### PR TITLE
Change return type of filter to just Optional<T>.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ export default class Optional<T> {
      * predicate, otherwise an empty Optional
      * @throws Error if the predicate is null
      */
-    filter(predicate: (value: T) => boolean): Optional<T | null | undefined>;
+    filter(predicate: (value: T) => boolean): Optional<T>;
 
     /**
      * If a value is present, apply the provided mapping function to it, and if the result is non-null,


### PR DESCRIPTION
Contrary to the Typescript typing, the filter function doesn't change the inner Optional type. This PR fixes the TS declaration of filter to return Optional\<T> instead of Optional<T | null | undefined>.

Note that the implementation of filter is correct, only the TS type is off.